### PR TITLE
Add postMessage notifications for SharePoint iframe integration

### DIFF
--- a/smapServer/WebContent/js/app/changeset.js
+++ b/smapServer/WebContent/js/app/changeset.js
@@ -186,6 +186,20 @@ export default {
                             responseFn();
                         }
 
+                        // Notify parent window (SharePoint extension hosting the editor in an iframe)
+                        if (data.success > 0 && window.parent && window.parent !== window) {
+                            try {
+                                window.parent.postMessage({
+                                    type: 'smapAction',
+                                    action: 'formEdited',
+                                    status: 'success',
+                                    surveyIdent: globals.model.survey.ident,
+                                    surveyId: globals.model.survey.id,
+                                    surveyName: globals.model.survey.displayName
+                                }, '*');
+                            } catch (e) { /* parent unreachable */ }
+                        }
+
                         // Report success and failure
                         globals.model.lastChanges = data.changeSet;
                         $('#successLabel .counter').html(data.success);

--- a/smapServer/WebContent/js/app/common.js
+++ b/smapServer/WebContent/js/app/common.js
@@ -2404,6 +2404,20 @@ function createNewSurvey(name, existing, existing_survey, shared_results, callba
 
 				saveCurrentProject(-1, globals.gCurrentSurvey, undefined);	// Save the current survey id
 
+				// Notify parent window (SharePoint extension hosting the editor in an iframe)
+				if(window.parent && window.parent !== window) {
+					try {
+						window.parent.postMessage({
+							type: 'smapAction',
+							action: 'formCreated',
+							status: 'success',
+							surveyIdent: data.ident,
+							surveyId: data.id,
+							surveyName: data.displayName
+						}, '*');
+					} catch (e) { /* parent unreachable */ }
+				}
+
 				setLanguages(data.languages, callback);
 
 				if (typeof callback == "function") {

--- a/smapServer/WebContent/js/app/common.js
+++ b/smapServer/WebContent/js/app/common.js
@@ -1994,6 +1994,10 @@ function getQuestionList(sId, language, qId, groupId, callback, setGroupList, vi
 					globals.gSelector.setSurveyQuestions(sId, language, data);
 					setSurveyViewQuestions(data, qId, view, dateqId, qName, assignQuestion, scQuestion);
 
+					if($('.sp_update_options').is(':visible')) {
+						spRefreshFieldSelects();
+					}
+
 					if (setGroupList) {
 						var vh = globals.viewHandlers || {};
 						if (typeof vh.setSurveyViewQuestionGroups === "function") vh.setSurveyViewQuestionGroups(data, groupId);
@@ -5827,8 +5831,8 @@ function spRefreshFieldSelects() {
 		$(this).empty();
 		$('<option>').val('').text('').appendTo($(this));
 		qList.forEach(function(q) {
-			$('<option>').val(q.name).text(q.name).appendTo($('.sp_field_select'));
-		});
+			$('<option>').val(q.name).text(q.name).appendTo($(this));
+		}.bind(this));
 		if(current) $(this).val(current);
 	});
 }
@@ -5915,6 +5919,7 @@ function setupSharePointNotification() {
 function spOperationChanged(operation) {
 	if(operation === 'update') {
 		$('.sp_update_options').show();
+		spRefreshFieldSelects();
 	} else {
 		$('.sp_update_options').hide();
 	}


### PR DESCRIPTION
## Summary

The SMAP form editor can be embedded in a cross-origin iframe by a SharePoint extension. The host page has no way to know when a form was created or edited inside that iframe. These changes make the editor emit `postMessage` events to the parent window so the SharePoint host can react (e.g. refresh its view, store the new survey ident).

## Changes

**postMessage notifications**

- `common.js` (`createNewSurvey`) — after a new survey is created, posts a `formCreated` message to the parent window with the survey ident, id, and display name.
- `changeset.js` — after a successful edit save (`data.success > 0`), posts a `formEdited` message with the same survey details.
- Both are guarded by a `window.parent !== window` check (only fires when actually iframed) and wrapped in try/catch so an unreachable parent is harmless. Message shape: `{ type: 'smapAction', action, status, surveyIdent, surveyId, surveyName }`.

**Match Field dropdown fix**

When configuring a SharePoint "update" notification, the Match Field dropdown was not populating:

- `spRefreshFieldSelects()` appended options to *all* `.sp_field_select` elements instead of the one currently being iterated, so per-select state (the preserved `current` value) was applied to the wrong elements. Changed to append to `$(this)` with a bound callback.
- The field selects are now refreshed when the question list loads (`common.js`) and when the operation is switched to `update` (`spOperationChanged`), so the dropdown is populated at the points where it becomes visible.

Tested locally via a hot-fixed deployment.