### PR TITLE
Make webform location configurable via WEBFORM_PATH env var

### DIFF
--- a/smapServer/dep.sh
+++ b/smapServer/dep.sh
@@ -82,7 +82,7 @@ convert_lang_files "$SCRIPT_DIR/smapServer"
 
 # Include webform javascript bundle and css files
 echo "Adding webform bundle to $SCRIPT_DIR/smapServer"
-pushd /Users/neilpenman/git/webform
+pushd "${WEBFORM_PATH:-/Users/neilpenman/git/webform}"
 ./deploy.sh $1
 popd
 cp -R WebContent/build $SCRIPT_DIR/smapServer


### PR DESCRIPTION
## What

One-line change to `smapServer/dep.sh`: allow overriding the webform clone location via a `WEBFORM_PATH` environment variable. Falls back to the existing hardcoded `/Users/neilpenman/git/webform` if the variable is unset, so existing setups are unaffected.

## Why

The current hardcoded path means the build only works on a machine where the webform clone lives at exactly that path. Anyone with a different layout (different username, different parent directory, Linux/Windows checkouts, etc.) has to either:

- Edit the script locally (creates a tracked-file modification that risks being committed accidentally)
- Symlink their webform into the hardcoded location (encodes someone else's username into their filesystem)

A `${VAR:-default}` shell fallback is the standard fix for this — zero behaviour change for anyone not setting the env var, opt-in flexibility for anyone who needs it.

## Testing

Tested locally on Linux (Ubuntu 24.04 in WSL):

- With `WEBFORM_PATH` unset: script attempts to `pushd /Users/neilpenman/git/webform` as before
- With `WEBFORM_PATH=/some/other/path` exported: script uses that path